### PR TITLE
roscpp dependency needed for kinetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,11 @@ cmake_minimum_required(VERSION 2.8.3)
 project(tue_config)
 
 find_package(catkin REQUIRED COMPONENTS
+    roscpp
     tue_filesystem
 )
 
-find_package(roslib)
+find_package(roslib REQUIRED)
 
 catkin_python_setup()
 

--- a/package.xml
+++ b/package.xml
@@ -10,9 +10,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roscpp</build_depend>
   <build_depend>tue_filesystem</build_depend>
   <build_depend>yaml-cpp</build_depend>
 
+  <run_depend>roscpp</run
   <run_depend>tue_filesystem</run_depend>
   <run_depend>yaml-cpp</run_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <build_depend>tue_filesystem</build_depend>
   <build_depend>yaml-cpp</build_depend>
 
-  <run_depend>roscpp</run
+  <run_depend>roscpp</run_depend>
   <run_depend>tue_filesystem</run_depend>
   <run_depend>yaml-cpp</run_depend>
 


### PR DESCRIPTION
Apparently the ros kinetic compilation is not able to find the roslib anymore with the current configuration. Adding the roscpp dependency for the c++ files solves this problem.