### PR TITLE
Fix whitespace issues

### DIFF
--- a/include/tue/config/reader_writer.h
+++ b/include/tue/config/reader_writer.h
@@ -159,6 +159,20 @@ public:
     }
 
     /**
+     * @brief setValue<string> set child value with key 'name' and value 'value', value is stripped from leading and trailing whitespace
+     * @param name name of the key
+     * @param value value of the value
+     */
+    void setValue(const std::string& name, std::string value)
+    {
+        trim(value);
+
+        Variant var(value);
+        Label label = cfg_->getOrAddLabel(name);
+        cfg_->nodes[idx_]->setValue(label, var);
+    }
+
+    /**
      * @brief addArrayItem create a new item in the array
      * @return indicates succes, can fail if current node isn't in an array
      */

--- a/include/tue/config/reader_writer.h
+++ b/include/tue/config/reader_writer.h
@@ -159,7 +159,8 @@ public:
     }
 
     /**
-     * @brief setValue<string> set child value with key 'name' and value 'value', value is stripped from leading and trailing whitespace
+     * @brief setValue<string> set child value with key 'name' and value 'value',
+     * value is stripped from leading and trailing whitespace
      * @param name name of the key
      * @param value value of the value
      */

--- a/include/tue/config/types.h
+++ b/include/tue/config/types.h
@@ -22,6 +22,47 @@ typedef boost::shared_ptr<const Node> NodeConstPtr;
 
 }
 
+// Trim functions from https://stackoverflow.com/a/217605
+// trim from start (in place)
+static inline void ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {return !std::isspace(ch);}));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s)
+{
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {return !std::isspace(ch);}).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s)
+{
+    ltrim(s);
+    rtrim(s);
+}
+
+// trim from start (copying)
+static inline std::string ltrim_copy(std::string s)
+{
+    ltrim(s);
+    return s;
+}
+
+// trim from end (copying)
+static inline std::string rtrim_copy(std::string s)
+{
+    rtrim(s);
+    return s;
+}
+
+// trim from both ends (copying)
+static inline std::string trim_copy(std::string s)
+{
+    trim(s);
+    return s;
+}
+
 } // end namespace tue
 
 #endif

--- a/include/tue/config/writer.h
+++ b/include/tue/config/writer.h
@@ -54,6 +54,21 @@ public:
     }
 
     /**
+     * @brief setValue<string> set child value with key 'name' and value 'value',
+     * value is stripped from leading and trailing whitespace
+     * @param name name of the key
+     * @param value value of the value
+     */
+    void setValue(const std::string& name, std::string value)
+    {
+        trim(value);
+
+        Variant var(value);
+        Label label = cfg_->getOrAddLabel(name);
+        cfg_->nodes[idx_]->setValue(label, var);
+    }
+
+    /**
      * @brief endArray go to parrent of current array, wrapping end() for readibility
      * @return indicates succes, see end() for more information
      */

--- a/src/loaders/yaml.cpp
+++ b/src/loaders/yaml.cpp
@@ -85,6 +85,21 @@ bool yamlScalarToVariant(const std::string& key, const YAML::Node& n, ReaderWrit
         return false;
     }
 
+    char* pEnd;
+    int i = (int) std::strtol(s_resolved.c_str(), &pEnd, 10);
+    if (pEnd[0] == 0)
+    {
+        config.setValue(key, i);
+        return true;
+    }
+
+    double d = std::strtod(s_resolved.c_str(), &pEnd);
+    if (pEnd[0] == 0)
+    {
+        config.setValue(key, d);
+        return true;
+    }
+
     config.setValue(key, s_resolved);
     return true;
 

--- a/src/loaders/yaml.cpp
+++ b/src/loaders/yaml.cpp
@@ -71,6 +71,13 @@ bool yamlScalarToVariant(const std::string& key, const YAML::Node& n, ReaderWrit
         return false;
     }
 
+    // Make sure that empty strings("") are set as string
+    if (s_resolved.empty())
+    {
+        config.setValue(key, s_resolved);
+        return true;
+    }
+
     char* pEnd;
     int i = (int) std::strtol(s_resolved.c_str(), &pEnd, 10);
     if (pEnd[0] == 0)

--- a/src/loaders/yaml.cpp
+++ b/src/loaders/yaml.cpp
@@ -60,20 +60,6 @@ bool yamlScalarToVariant(const std::string& key, const YAML::Node& n, ReaderWrit
     return true;
 #else
 
-    try
-    {
-        config.setValue(key, n.as<int>());
-        return true;
-    }
-    catch (YAML::BadConversion& e) {}
-
-    try
-    {
-        config.setValue(key, n.as<double>());
-        return true;
-    }
-    catch (YAML::BadConversion& e) {}
-
     s = n.as<std::string>();
 
     // Check and resolve possible resolve functions ( "$( ... )" )

--- a/test/sdf_gtest.cpp
+++ b/test/sdf_gtest.cpp
@@ -6,7 +6,7 @@
 
 #include "tue/filesystem/path.h"
 
-static tue::config::ReaderWriter config;
+tue::config::ReaderWriter config;
 
 TEST(SDF, LoadSDF)
 {

--- a/test/sdf_gtest.cpp
+++ b/test/sdf_gtest.cpp
@@ -6,7 +6,7 @@
 
 #include "tue/filesystem/path.h"
 
-tue::config::ReaderWriter config;
+static tue::config::ReaderWriter config;
 
 TEST(SDF, LoadSDF)
 {

--- a/test/test_yaml_and_show.cpp
+++ b/test/test_yaml_and_show.cpp
@@ -19,8 +19,6 @@
 
 int main(int argc, char **argv)
 {
-    tue::config::ReaderWriter config;
-
     if (argc < 2)
     {
         std::cout << "Please provide yaml config file." << std::endl;


### PR DESCRIPTION
Problem occurs in yaml when tabs are followed by a comment.

The solution is generic and used by all loaders as I don't think whitespace is functional here.

Fixes #11

Merge after: tue-robotics/ed_navigation#15, tue-robotics/ed_gui_server#18 and tue-robotics/ed_localization#8